### PR TITLE
remove trailing slash

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 bs4
 requests
 lxml
-psycopg2
+psycopg2-binary
 pre-commit
 tqdm
 requests-toolbelt

--- a/src/project_settings.py
+++ b/src/project_settings.py
@@ -9,7 +9,7 @@ settings = {
     "resume_dir": "__temp/resume/",
 
     "backend": {
-        "endpoint": "http://dev-5.pc:85/server/api/",
+        "endpoint": "http://dev-5.pc:85/server/api",  # without trailing slash
         "user": "test@test.edu",
         "password": "admin",
         "authentication": True,


### PR DESCRIPTION
## Problem description
Because of how other request strings are constructed, the backend might throw `The request was rejected because the URL contained a potentiall y malicious String \"//\""` when using a trailing slash here.