### PR TITLE
use psycopg2-binary instead of psycopg2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 bs4
 requests
 lxml
-psycopg2
+psycopg2-binary
 pre-commit
 tqdm
 requests-toolbelt


### PR DESCRIPTION
## Problem description
`psycopg2` comes with 'heavier' additional requirements: `build-essential, libpq-dev, gcc`; otoh, `psycopg2-binary` is 'lighter', that is, it comes with less additional requirements (not requiring a compiler or external libraries). 

Note that it "is a practical choice for development and testing but in production it is advised to use the package built from sources."
