### PR TITLE
add wheel requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ tqdm
 requests-toolbelt
 six
 pysolr~=3.9.0
+wheel


### PR DESCRIPTION
## Problem description
`wheel` is later needed by pysolr (or by what is done with pywolr) - and otherwise throws an error (unless already available by the system...).
