### PR TITLE
Fix regex excape

### DIFF
--- a/src/pump/_group.py
+++ b/src/pump/_group.py
@@ -15,7 +15,7 @@ def _epersongroup_process(repo, v5data: list, v7data: list):
             "Cannot validate using _epersongroup_process because repo is None")
         return None, None
 
-    rec = re.compile("(COLLECTION|COMMUNITY)_(\d+)_(.*)")
+    rec = re.compile(r"(COLLECTION|COMMUNITY)_(\d+)_(.*)")
     v5data_new = []
     for val in v5data:
         m = rec.match(val)


### PR DESCRIPTION
| Phases            | MS | MM  |  MK  | JR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
Issue with regex escaping on python 3.13